### PR TITLE
ZZMoove: Add built-in support for defining default profiles

### DIFF
--- a/cpufreq_zzmoove.c
+++ b/cpufreq_zzmoove.c
@@ -612,7 +612,13 @@
 
 // ZZ: include profiles header file and set name for 'custom' profile (informational for a changed profile value)
 #include "cpufreq_zzmoove_profiles.h"
-#define DEF_PROFILE_NUMBER				(0)	// ZZ: default profile number (profile = 0 = 'none' = tuneable mode)
+
+// ZZ: default profile number (profile = 0 = 'none' = tuneable mode)
+#ifdef CONFIG_CPU_FREQ_GOV_ZZMOOVE_DEFAULT_PROFILE
+#define DEF_PROFILE_NUMBER				CONFIG_CPU_FREQ_GOV_ZZMOOVE_DEFAULT_PROFILE
+#else
+#define DEF_PROFILE_NUMBER				(0)
+#endif
 static char custom_profile[20] = "custom";			// ZZ: name to show in sysfs if any profile value has changed
 
 // Yank: enable/disable debugging code


### PR DESCRIPTION
Full commit: https://github.com/ArchiDroid/ArchiKernel/commit/9c5639fe21e508c918567d90eee3aeacd03b5dd7
